### PR TITLE
Fix API key authentication header

### DIFF
--- a/market/authentication.py
+++ b/market/authentication.py
@@ -13,3 +13,6 @@ class APIKeyAuthentication(BaseAuthentication):
         except User.DoesNotExist:
             raise AuthenticationFailed('Invalid API Key')
         return (user, None)
+
+    def authenticate_header(self, request):
+        return 'Token'


### PR DESCRIPTION
## Summary
- return `Token` header for failed API key authentication

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_684867edd3e483329c9f45460e23ae89