### PR TITLE
Fix flexible API key handling

### DIFF
--- a/market/authentication.py
+++ b/market/authentication.py
@@ -4,12 +4,18 @@ from .models import User
 
 class APIKeyAuthentication(BaseAuthentication):
     def authenticate(self, request):
-        auth_header = request.headers.get("Authorization", "")
-        if not auth_header.lower().startswith("token "):
+        auth_header = request.headers.get("Authorization", "").strip()
+        if auth_header.lower().startswith("token "):
+            api_key = auth_header.split(" ", 1)[1]
+        else:
+            api_key = auth_header
+        if not api_key:
             return None
-        api_key = auth_header.split(" ", 1)[1]
         try:
             user = User.objects.get(api_key=api_key)
         except User.DoesNotExist:
             raise AuthenticationFailed('Invalid API Key')
         return (user, None)
+
+    def authenticate_header(self, request):
+        return 'Token'


### PR DESCRIPTION
## Summary
- allow Authorization header without `Token` prefix

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_684867edd3e483329c9f45460e23ae89