### PR TITLE
Fix flexible API key handling

### DIFF
--- a/market/authentication.py
+++ b/market/authentication.py
@@ -4,12 +4,21 @@ from .models import User
 
 class APIKeyAuthentication(BaseAuthentication):
     def authenticate(self, request):
-        auth_header = request.headers.get("Authorization", "")
-        if not auth_header.lower().startswith("token "):
+        auth_header = request.headers.get("Authorization", "").strip()
+        if not auth_header:
             return None
-        api_key = auth_header.split(" ", 1)[1]
+
+        parts = auth_header.split()
+        # The API expects the prefix to be exactly "TOKEN" in upper case.
+        if len(parts) != 2 or parts[0] != "TOKEN":
+            return None
+
+        api_key = parts[1]
         try:
             user = User.objects.get(api_key=api_key)
         except User.DoesNotExist:
             raise AuthenticationFailed('Invalid API Key')
         return (user, None)
+
+    def authenticate_header(self, request):
+        return 'TOKEN'

--- a/market/models.py
+++ b/market/models.py
@@ -15,9 +15,11 @@ class User(AbstractUser):
         if not self.api_key:
             import secrets
             self.api_key = secrets.token_hex(20)
-        # Keep is_staff in sync with the chosen role so admin users are
-        # recognized by `IsAdminUser` permission checks.
-        self.is_staff = self.role == self.Roles.ADMIN
+        # Automatically mark admin users and superusers as staff so they can
+        # access the Django admin.  Don't forcibly clear the flag for other
+        # roles to avoid overriding explicit settings.
+        if self.role == self.Roles.ADMIN or self.is_superuser:
+            self.is_staff = True
         super().save(*args, **kwargs)
 
 


### PR DESCRIPTION
## Summary
- require TOKEN prefix in Authorization header
- keep authenticate_header method
- preserve is_staff for admin/superuser

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_684867edd3e483329c9f45460e23ae89