### PR TITLE
Add RUB instrument and zero balance defaults

### DIFF
--- a/market/views.py
+++ b/market/views.py
@@ -30,6 +30,7 @@ BALANCES = defaultdict(lambda: defaultdict(float))
 INSTRUMENTS = {
     "MEMCOIN": {"name": "Memecoin", "ticker": "MEMCOIN"},
     "DODGE": {"name": "Dodge", "ticker": "DODGE"},
+    "RUB": {"name": "Ruble", "ticker": "RUB"},
 }
 
 
@@ -255,10 +256,11 @@ class TransactionHistoryView(APIView):
 class BalanceView(APIView):
     permission_classes = [permissions.IsAuthenticated]
     def get(self, request):
-        data = {"MEMCOIN": 0, "DODGE": 100500}
         user_id = str(request.user.id)
-        data = dict(BALANCES[user_id])
-        return Response(data, status=200)
+        balances = dict(BALANCES[user_id])
+        for ticker in INSTRUMENTS:
+            balances.setdefault(ticker, 0)
+        return Response(balances, status=200)
 
 class OrderListCreateView(APIView):
     permission_classes = [permissions.IsAuthenticated]


### PR DESCRIPTION
## Summary
- add RUB as a default instrument
- always include all instrument tickers in balance response

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68495313d348833293d5a008a83bb916